### PR TITLE
Add CODEOWNERS for mandatory owner approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every change requires approval from the project owner
+* @mopanc


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` requiring `@mopanc` approval on all file changes
- Branch protection updated to enforce code owner reviews

This ensures no PR can be merged without the project owner's explicit approval.

## Test plan

- [x] Verify CODEOWNERS file is picked up by GitHub
- [x] Confirm PRs show @mopanc as required reviewer
