### PR TITLE
Add token savings docs and project roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,26 +99,60 @@ Weights are configurable via the `weights` option in `score()`.
 
 The threshold is configurable via `--threshold` (CLI) or `threshold` option (API).
 
+## Token Savings
+
+Every MCP tool response includes a `tokenSavings` field that shows how many LLM tokens you save compared to manual research (web searches, page fetches, reasoning).
+
+```json
+"tokenSavings": {
+  "responseTokens": 47,
+  "manualEstimate": 11100,
+  "saved": 11053,
+  "percentSaved": 100,
+  "manualSteps": [
+    "WebSearch: \"{package} npm quality maintenance\" (~800 tokens)",
+    "WebFetch: npm registry page (~3000 tokens)",
+    "WebFetch: GitHub repo for activity/stars (~3000 tokens)",
+    "WebSearch: \"{package} vulnerabilities\" (~800 tokens)",
+    "WebFetch: advisories page (~3000 tokens)",
+    "Reasoning: compute weighted score (~500 tokens)"
+  ]
+}
+```
+
+This is automatically included in every response — no configuration needed. It helps teams quantify the cost savings of using depguard in their AI workflows.
+
 ## MCP Server
 
-depguard includes a built-in MCP (Model Context Protocol) server for AI agent integration.
+depguard includes a built-in [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) server for AI agent integration. It works with **any MCP-compatible client**.
 
-### Configure in Claude Code
+### Compatible AI clients
 
-Add to your Claude Code MCP settings (`~/.claude/settings.json` or project `.claude/settings.json`):
+| Client | Configuration |
+|--------|--------------|
+| Claude Code | `.mcp.json` or `~/.claude/settings.json` |
+| Claude Desktop | `claude_desktop_config.json` |
+| Cursor | MCP settings in IDE |
+| Windsurf | MCP settings in IDE |
+| Continue.dev | `config.json` MCP section |
+| Cline / Roo Code | MCP settings |
+
+### Setup
+
+Add to your MCP configuration file:
 
 ```json
 {
   "mcpServers": {
     "depguard": {
-      "command": "node",
-      "args": ["/path/to/depguard/dist/mcp.js"]
+      "command": "depguard-mcp",
+      "args": []
     }
   }
 }
 ```
 
-Or if installed globally:
+Or using npx (no install needed):
 
 ```json
 {

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,59 @@
+# Roadmap
+
+The plan for depguard.ai — where we are and where we're going.
+
+## Released
+
+### v1.0.0 — Core Auditor
+- [x] Full security audit (vulnerabilities, CVEs, advisories)
+- [x] Package scoring (0-100) across 5 dimensions
+- [x] npm search with quality ranking
+- [x] Install vs write-from-scratch advisor
+- [x] License compatibility checker (15+ SPDX identifiers)
+- [x] MCP server (JSON-RPC 2.0 over stdio)
+- [x] CLI tool
+- [x] In-memory cache with TTL
+- [x] 54 offline tests
+
+### v1.1.0 — Token Savings
+- [x] Token savings estimator in every MCP response
+- [x] Manual step breakdown (what the alternative would cost)
+- [x] Exported `calculateSavings()` and `TokenSavings` type
+
+## Planned
+
+### v1.2.0 — Smarter Analysis
+- [ ] **Dependency tree audit** — recursively audit transitive dependencies, not just direct
+- [ ] **Supply chain risk score** — detect typosquatting, suspicious maintainer changes, and new-package-with-high-downloads patterns
+- [ ] **Bundle size estimation** — report install size and unpacked size to help decide if the package is worth the weight
+- [ ] **Alternative suggestions** — when a package scores low, automatically suggest better alternatives
+
+### v1.3.0 — Performance & Caching
+- [ ] **Persistent cache** — file-based cache that survives process restarts (important for MCP servers that restart per session)
+- [ ] **Parallel registry requests** — batch multiple package lookups into concurrent requests
+- [ ] **Configurable cache TTL** — allow users to set cache duration via environment variable or config
+- [ ] **Rate limit handling** — automatic backoff and retry on npm registry rate limits
+
+### v1.4.0 — Ecosystem Expansion
+- [ ] **PyPI support** — audit Python packages with the same scoring model
+- [ ] **Cargo support** — audit Rust crates
+- [ ] **Go modules support** — audit Go packages
+- [ ] **Multi-ecosystem advisor** — `should_use` recommends across npm, PyPI, Cargo, and Go
+
+### v1.5.0 — Project-Level Intelligence
+- [ ] **Batch audit** — audit all dependencies in a `package.json` at once
+- [ ] **Drift detection** — compare current dependency versions against latest and flag outdated/vulnerable ones
+- [ ] **License report** — generate a full license compliance report for all project dependencies
+- [ ] **CI integration** — GitHub Action that runs depguard on PRs that modify `package.json`
+
+### Future Ideas
+- [ ] **Vulnerability fix suggestions** — recommend specific version upgrades that resolve CVEs
+- [ ] **Maintainer reputation** — score maintainers based on response time, release frequency, and multi-package track record
+- [ ] **Custom scoring weights** — allow users to define their own scoring profiles via config file
+- [ ] **Historical trends** — track how a package's score changes over time
+- [ ] **API mode** — HTTP server for teams that want to run depguard as a shared service
+- [ ] **npm publish** — publish to npm registry for easy global installation
+
+## Contributing
+
+Ideas and contributions are welcome. Open an issue to discuss before submitting a PR.


### PR DESCRIPTION
## Summary

- **README**: Added Token Savings section with JSON example showing savings metrics
- **README**: Expanded MCP Server section with compatibility table (Claude Code, Cursor, Windsurf, Continue.dev, Cline)
- **README**: Simplified setup configuration
- **ROADMAP**: Full project roadmap from v1.0 through v1.5 and future ideas

## Test plan

- [x] Verify README renders correctly on GitHub
- [x] Review roadmap priorities