### PR TITLE
Add npm publish with provenance attestation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint
+      - run: npm test
+      - run: npm audit --audit-level=high
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- New `publish.yml` workflow triggered on GitHub releases
- Runs full test matrix (Node 18/20/22) before publishing
- Publishes to npm with `--provenance` flag for supply chain verification
- Requires `NPM_TOKEN` secret in repo settings

## Setup needed

1. Generate an npm automation token at https://www.npmjs.com/settings/tokens
2. Add it as `NPM_TOKEN` in repo Settings > Secrets > Actions

## Why

Socket.dev scored our supply chain security at 76/100. Provenance attestation cryptographically proves the package was built from this repo, improving trust and score.