### PR TITLE
Fix: filter advisories by version (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-03-17
+
+### Fixed
+
+- **Critical: Filter GitHub advisories by version** — previously reported historical advisories that were already patched in the current version, causing false positives. Now only reports vulnerabilities that actually affect the installed version.
+- Added semver range checker for accurate version matching against advisory ranges
+
 ## [1.2.0] - 2026-03-16
 
 ### Added
@@ -63,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory cache with TTL for registry requests
 - Comprehensive test suite (54 tests)
 
+[1.2.1]: https://github.com/mopanc/depguard/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/mopanc/depguard/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/mopanc/depguard/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/mopanc/depguard/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ depguard combines two advisory databases for maximum coverage:
 | **npm Registry** | Advisories from `npm audit` |
 | **GitHub Advisory Database** | GHSA advisories, often not in npm |
 
-Results are deduplicated and each advisory includes a `source` field (`npm` or `github`).
+Results are deduplicated, filtered by the current package version (only vulnerabilities that actually affect the installed version are reported), and each advisory includes a `source` field (`npm` or `github`).
 
 ### Caching
 
@@ -257,7 +257,7 @@ A dependency is compatible if its license is equally or more permissive than you
 ```bash
 npm run build    # compile TypeScript
 npm run lint     # ESLint (strict)
-npm test         # 54 tests (all offline)
+npm test         # 84 tests (all offline)
 npm run check    # build + lint + test + audit
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depguard-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Audit npm packages for security, maintenance, licenses and dependencies. Recommends install or write-from-scratch.",
   "author": "Jorge Morais",
   "license": "Apache-2.0",

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -2,6 +2,7 @@ import type { AuditReport, FetchFn, NpmAdvisory, VulnerabilitySummary } from './
 import { fetchPackage, fetchDownloads, fetchAdvisories, fetchGitHubAdvisories } from './registry.js'
 import { checkLicenseCompatibility } from './license.js'
 import { analyzeScripts } from './script-analysis.js'
+import { satisfiesRange } from './semver.js'
 
 const INSTALL_SCRIPT_NAMES = ['preinstall', 'install', 'postinstall']
 
@@ -23,11 +24,12 @@ function mapGitHubSeverity(severity: string): NpmAdvisory['severity'] {
 function mergeAdvisories(
   npmAdvisories: NpmAdvisory[],
   ghAdvisories: Awaited<ReturnType<typeof fetchGitHubAdvisories>>,
+  currentVersion: string,
 ): NpmAdvisory[] {
   const seen = new Set<string>()
   const merged: NpmAdvisory[] = []
 
-  // Add npm advisories first
+  // Add npm advisories first (npm bulk endpoint already filters by version)
   for (const adv of npmAdvisories) {
     seen.add(adv.url)
     merged.push({ ...adv, source: 'npm' as const })
@@ -44,13 +46,19 @@ function mergeAdvisories(
     const ghsaInNpm = npmAdvisories.some(a => a.url.includes(gh.ghsa_id))
     if (ghsaInNpm) continue
 
+    // Filter: only include if current version is actually affected
     const vuln = gh.vulnerabilities?.[0]
+    const range = vuln?.vulnerable_version_range
+    if (range && !satisfiesRange(currentVersion, range)) {
+      continue // Current version is NOT in the vulnerable range — skip
+    }
+
     merged.push({
       id: parseInt(gh.ghsa_id.replace(/\D/g, '').slice(0, 8)) || 0,
       title: gh.summary,
       severity: mapGitHubSeverity(gh.severity),
       url: gh.html_url,
-      vulnerable_versions: vuln?.vulnerable_version_range ?? '*',
+      vulnerable_versions: range ?? '*',
       patched_versions: vuln?.first_patched_version ?? null,
       cwe: gh.cwes?.map(c => c.cwe_id),
       cvss: gh.cvss ? { score: gh.cvss.score, vectorString: gh.cvss.vector_string } : undefined,
@@ -113,7 +121,7 @@ export async function audit(
     }),
   ])
 
-  const advisories = mergeAdvisories(npmAdvisories, ghAdvisories)
+  const advisories = mergeAdvisories(npmAdvisories, ghAdvisories, latestVersion)
 
   const license = versionData?.license ?? pkg.license ?? null
   const deps = versionData?.dependencies ?? {}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -19,7 +19,7 @@ import { calculateSavings } from './tokens.js'
 
 const SERVER_INFO = {
   name: 'depguard',
-  version: '1.2.0',
+  version: '1.2.1',
 }
 
 const TOOLS = [

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -1,0 +1,80 @@
+/**
+ * Minimal semver range checker — zero dependencies.
+ * Supports common version range patterns from GitHub advisories:
+ *   "< 4.0.0", ">= 1.0.0, < 2.0.0", "<= 3.5.0", "= 1.2.3"
+ *
+ * Does NOT support: ||, ~, ^, *, x, pre-release tags, build metadata.
+ * This is intentional — advisory ranges use simple comparators.
+ */
+
+interface SemVer {
+  major: number
+  minor: number
+  patch: number
+}
+
+function parse(version: string): SemVer | null {
+  // Strip leading 'v' and any pre-release/build suffix
+  const clean = version.replace(/^v/, '').replace(/[-+].*$/, '').trim()
+  const parts = clean.split('.')
+  if (parts.length < 2) return null
+
+  const major = parseInt(parts[0], 10)
+  const minor = parseInt(parts[1], 10)
+  const patch = parts.length >= 3 ? parseInt(parts[2], 10) : 0
+
+  if (isNaN(major) || isNaN(minor) || isNaN(patch)) return null
+  return { major, minor, patch }
+}
+
+function compare(a: SemVer, b: SemVer): number {
+  if (a.major !== b.major) return a.major - b.major
+  if (a.minor !== b.minor) return a.minor - b.minor
+  return a.patch - b.patch
+}
+
+function matchComparator(version: SemVer, op: string, target: SemVer): boolean {
+  const cmp = compare(version, target)
+  switch (op) {
+    case '<': return cmp < 0
+    case '<=': return cmp <= 0
+    case '>': return cmp > 0
+    case '>=': return cmp >= 0
+    case '=': return cmp === 0
+    default: return cmp === 0
+  }
+}
+
+/**
+ * Check if a version satisfies a vulnerability range string.
+ * Returns true if the version IS vulnerable (falls within the range).
+ *
+ * Examples:
+ *   satisfiesRange("4.17.21", "< 4.17.20")  → false (not vulnerable)
+ *   satisfiesRange("4.17.19", "< 4.17.20")  → true  (vulnerable)
+ *   satisfiesRange("1.5.0", ">= 1.0.0, < 2.0.0") → true (vulnerable)
+ */
+export function satisfiesRange(version: string, range: string): boolean {
+  const ver = parse(version)
+  if (!ver) return true // If we can't parse, assume vulnerable (safe default)
+
+  if (!range || range === '*') return true
+
+  // Split by comma for compound ranges: ">= 1.0.0, < 2.0.0"
+  const parts = range.split(',').map(s => s.trim()).filter(Boolean)
+
+  for (const part of parts) {
+    const match = part.match(/^(>=|<=|>|<|=)\s*(.+)$/)
+    if (!match) continue
+
+    const op = match[1]
+    const target = parse(match[2])
+    if (!target) continue
+
+    if (!matchComparator(ver, op, target)) {
+      return false // One condition not met → not in vulnerable range
+    }
+  }
+
+  return true
+}

--- a/tests/semver.test.ts
+++ b/tests/semver.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { satisfiesRange } from '../src/semver.js'
+
+describe('satisfiesRange', () => {
+  it('returns true when version is in vulnerable range', () => {
+    assert.strictEqual(satisfiesRange('4.17.19', '< 4.17.20'), true)
+    assert.strictEqual(satisfiesRange('1.5.0', '>= 1.0.0, < 2.0.0'), true)
+    assert.strictEqual(satisfiesRange('0.3.0', '>= 0.1.0, < 0.4.0'), true)
+  })
+
+  it('returns false when version is NOT in vulnerable range', () => {
+    assert.strictEqual(satisfiesRange('4.17.21', '< 4.17.20'), false)
+    assert.strictEqual(satisfiesRange('2.0.0', '>= 1.0.0, < 2.0.0'), false)
+    assert.strictEqual(satisfiesRange('19.2.4', '< 0.4.2'), false)
+    assert.strictEqual(satisfiesRange('5.0.0', '>= 1.0.0, < 3.0.0'), false)
+  })
+
+  it('handles exact version match', () => {
+    assert.strictEqual(satisfiesRange('1.2.3', '= 1.2.3'), true)
+    assert.strictEqual(satisfiesRange('1.2.4', '= 1.2.3'), false)
+  })
+
+  it('handles <= operator', () => {
+    assert.strictEqual(satisfiesRange('3.5.0', '<= 3.5.0'), true)
+    assert.strictEqual(satisfiesRange('3.5.1', '<= 3.5.0'), false)
+  })
+
+  it('handles >= operator', () => {
+    assert.strictEqual(satisfiesRange('3.5.0', '>= 3.5.0'), true)
+    assert.strictEqual(satisfiesRange('3.4.9', '>= 3.5.0'), false)
+  })
+
+  it('handles version with v prefix', () => {
+    assert.strictEqual(satisfiesRange('v4.17.19', '< 4.17.20'), true)
+    assert.strictEqual(satisfiesRange('v4.17.21', '< 4.17.20'), false)
+  })
+
+  it('returns true for wildcard range', () => {
+    assert.strictEqual(satisfiesRange('1.0.0', '*'), true)
+  })
+
+  it('returns true for empty/null range', () => {
+    assert.strictEqual(satisfiesRange('1.0.0', ''), true)
+  })
+
+  it('returns true for unparseable version (safe default)', () => {
+    assert.strictEqual(satisfiesRange('not-a-version', '< 4.0.0'), true)
+  })
+
+  it('handles real-world GitHub advisory ranges', () => {
+    // React: advisory for versions < 0.4.2 should NOT affect 19.2.4
+    assert.strictEqual(satisfiesRange('19.2.4', '>= 0.4.0, < 0.4.2'), false)
+    // Express: advisory for < 4.21.2 SHOULD affect 4.21.1
+    assert.strictEqual(satisfiesRange('4.21.1', '< 4.21.2'), true)
+    // Express: but NOT 5.0.0
+    assert.strictEqual(satisfiesRange('5.0.0', '< 4.21.2'), false)
+  })
+})


### PR DESCRIPTION
Critical fix: stop reporting historical vulnerabilities already patched in current version. Fixes #31