### PR TITLE
feat: add --version flag and publish-time version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
     "README.md"
   ],
   "scripts": {
+    "check-version": "node --import tsx scripts/check-version.ts",
     "build": "tsc && cp -r src/data dist/data",
     "test": "node --import tsx --test tests/*.test.ts",
     "lint": "eslint src/ tests/",
     "audit:security": "npm audit --audit-level=high --omit=dev",
-    "check": "npm run build && npm run lint && npm test && npm run audit:security",
+    "check": "npm run check-version && npm run build && npm run lint && npm test && npm run audit:security",
     "prepublishOnly": "npm run check"
   },
   "devDependencies": {

--- a/scripts/check-version.ts
+++ b/scripts/check-version.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node --import tsx
+/**
+ * Verifies that DEPGUARD_VERSION in src/version.ts matches package.json#version.
+ * src/version.ts is the single source of truth; this script just guards against
+ * a forgotten update on either side. Wired into `prepublishOnly` via `npm run check`.
+ * Exits 0 on match, 1 on mismatch.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { DEPGUARD_VERSION } from '../src/version.js'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { version?: unknown }
+
+if (typeof pkg.version !== 'string' || !pkg.version) {
+  console.error('check-version: package.json#version is missing or not a string')
+  process.exit(1)
+}
+
+if (pkg.version !== DEPGUARD_VERSION) {
+  console.error(
+    `check-version: mismatch - package.json is ${pkg.version}, src/version.ts is ${DEPGUARD_VERSION}. ` +
+    `Update both before publishing.`,
+  )
+  process.exit(1)
+}
+
+console.log(`check-version: OK (${DEPGUARD_VERSION})`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { parseArgs } from 'node:util'
+import { DEPGUARD_VERSION } from './version.js'
 import { audit } from './audit.js'
 import { search } from './search.js'
 import { score } from './scorer.js'
@@ -27,8 +28,14 @@ const { values, positionals } = parseArgs({
     'include-vex': { type: 'boolean', default: false },
     'output': { type: 'string', short: 'o' },
     'help': { type: 'boolean', short: 'h', default: false },
+    'version': { type: 'boolean', short: 'v', default: false },
   },
 })
+
+if (values.version) {
+  console.log(DEPGUARD_VERSION)
+  process.exit(0)
+}
 
 // Launch MCP server when --mcp flag is passed
 if (values.mcp) {
@@ -67,6 +74,7 @@ Options:
   --include-vex            Sbom: include VEX vulnerability data (runs audit)
   -o, --output <file>      Sbom: write to file instead of stdout
   -h, --help               Show this help
+  -v, --version            Show version
 `)
   process.exit(0)
 }


### PR DESCRIPTION
Closes https://github.com/mopanc/depguard/issues/58

## Summary
- Adds `depguard-cli --version` (and `-v`) so end users can check the installed CLI version.
- Adds `scripts/check-version.ts` to guard against `src/version.ts` and `package.json#version` drifting apart. Wired into `npm run check` (which is `prepublishOnly`), so a forgotten bump on either side blocks publish.
- Zero new runtime or dev dependencies. The check script runs via `node --import tsx`, matching the style already used by `test` and `scripts/daily-scan.ts`.

## Test plan
- [x] `node dist/cli.js --version` prints `1.9.1`
- [x] `node dist/cli.js -v` prints `1.9.1`
- [x] `npm run check-version` exits 0 on match, prints `check-version: OK (1.9.1)`
- [x] Temporarily editing `src/version.ts` to `9.9.9` makes `npm run check-version` exit 1 with a clear instruction to bump both files
- [x] `--version` is documented in `--help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)